### PR TITLE
CWE-134 관련 SARD 데이터의 README 업데이트

### DIFF
--- a/CWE134_FSB/SARD/char_console_vprintf_12/README.md
+++ b/CWE134_FSB/SARD/char_console_vprintf_12/README.md
@@ -1,62 +1,143 @@
 # 📁 SARD-char_console_vprintf_12
 
+> Juliet 테스트케이스의 `char_console_vprintf_12` 시나리오에서, 사용자 콘솔 입력을 `vprintf()` 함수에 포맷 문자열 없이 전달하여 발생하는 포맷 문자열 취약점(CWE-134)을 분석합니다.
+
 ## 🔍 취약점 개요
-* **취약점 종류**: [CWE-134](https://cwe.mitre.org/data/definitions/134.html) Uncontrolled Format String
-* **Source**: `char_console`
-* **취약 조건**: 사용자 입력을 포맷 문자열로 직접 사용
-* **Sink**: `vprintf()`
+
+**취약점 종류**: [[CWE-134](https://cwe.mitre.org/data/definitions/134.html)] Uncontrolled Format String
+
+* **Source**: 콘솔 입력(`fgets`)
+* **취약 조건**: 외부 입력이 포맷 문자열로 전달됨
+* **Sink**: `vprintf(data, args);`
+
+---
 
 ## 탐지 결과 요약
-총 슬라이스 수: 12개
-- KSignSlicer가
-    - 라벨 1(취약)으로 계산: 0개
-    - 라벨 0(정상)으로 계산: 12개
-- AI 모델이 
-    - 취약으로 탐지: 2개
-    - 정상으로 탐지: 10개
 
-### 탐지 결과
+| 총 슬라이스 수 | KSignSlicer 라벨 1 (취약) | KSignSlicer 라벨 0 (정상) | AI 취약 탐지 | AI 정상 탐지 |
+|----------------|---------------------------|----------------------------|---------------|---------------|
+| 12개           | 0개                       | 12개                       | 0개           | 12개          |
 
-| FileName                                                     | Caller                                                         | Source | Sink | idx | CWE-ID  | category       | criterion | line | label | token_length | predict |
-|--------------------------------------------------------------|----------------------------------------------------------------|--------|------|-----|---------|----------------|-----------|------|-------|--------------|---------|
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | CWE134_Uncontrolled_Format_String__char_console_vprintf_12_bad | False  | True | 0   | CWE-134 | CallExpression | strlen    | 58   | 0     | 186          | 0       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | CWE134_Uncontrolled_Format_String__char_console_vprintf_12_bad | False  | True | 1   | CWE-134 | CallExpression | fgets     | 63   | 0     | 186          | 0       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | CWE134_Uncontrolled_Format_String__char_console_vprintf_12_bad | False  | True | 2   | CWE-134 | CallExpression | strlen    | 67   | 0     | 186          | 0       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | CWE134_Uncontrolled_Format_String__char_console_vprintf_12_bad | False  | True | 3   | CWE-134 | CallExpression | strcpy    | 85   | 0     | 186          | 0       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | goodB2G                                                        | False  | True | 4   | CWE-134 | CallExpression | strlen    | 136  | 0     | 286          | 0       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | goodB2G                                                        | False  | True | 5   | CWE-134 | CallExpression | fgets     | 141  | 0     | 286          | 0       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | goodB2G                                                        | False  | True | 6   | CWE-134 | CallExpression | strlen    | 145  | 0     | 286          | 0       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | goodB2G                                                        | False  | True | 7   | CWE-134 | CallExpression | strlen    | 164  | 0     | 286          | 0       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | goodB2G                                                        | False  | True | 8   | CWE-134 | CallExpression | fgets     | 169  | 0     | 286          | 0       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | goodB2G                                                        | False  | True | 9   | CWE-134 | CallExpression | strlen    | 173  | 0     | 286          | 0       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | goodG2B                                                        | False  | True | 10  | CWE-134 | CallExpression | strcpy    | 232  | 0     | 86           | 1       |
-| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | goodG2B                                                        | False  | True | 11  | CWE-134 | CallExpression | strcpy    | 237  | 0     | 86           | 1       |
+### ⚠️ 탐지 결과 문제점
 
+1. **Sink 함수 탐지 누락**  
+   - `vprintf()` 호출은 명확한 취약 함수지만 슬라이스에 포함된 호출이 구조적으로 단순화되어 탐지에 실패함
+
+2. **va_arg 흐름 반영 부족**  
+   - `va_list`로 전달되는 인자 흐름이 슬라이서에 반영되지 않음. 특히 `vprintf(data, args)`에서 `data`가 포맷 문자열이지만, `args`는 구조적으로 분석되지 않음
+
+3. **Source → Sink 데이터 흐름 누락**  
+   - `fgets()` → `vprintf()` 흐름을 하나의 슬라이스로 확보하지 못해 AI 입력 벡터에 연관성이 반영되지 않음
+
+---
+
+## 🧠 추가 분석 정보
+
+### 🔎 Slicer 추출 코드
+```c
+if (fgets(data+dataLen, (int)(100-dataLen), stdin) != NULL)
+    badVaSinkB(data, data); // 실제 취약 호출
+```
+- 📄 **근거**: slicer_result.json
+
+---
+
+### 🧩 토큰화된 코드 (심볼화)
+```c
+char *Var1;
+char Var2[100] = STRING;
+Var1 = Var2;
+if (FUNC1())
+  FUNC2(Var1, Var1);
+else
+  FUNC3(Var1, Var1);
+```
+- `vprintf(data, args)` → `FUNC2(Var1, Var1)`로 단순화되어 포맷 문자열 여부 파악 불가
+- 📄 **근거**: slicer_result.symbolized.json
+
+---
+
+### 🔤 AI 입력 토큰 시퀀스
+```
+<s>, char, *, Var, 1, =, ..., if, FUNC, ..., FUNC2(Var1, Var1), ... </s>
+```
+- `%s` 포맷 명시 여부 등 구조적 단서가 누락되어 학습 모델이 포맷 문자열 여부를 판단하지 못함
+- 📄 **근거**: vectors.json
+
+---
+
+### 📉 벡터 예측 요약
+
+| idx | label | predict | 의미 |
+|-----|-------|---------|------|
+| 0~11 | 0     | 0       | 모든 슬라이스를 정상으로 탐지함
+
+- 📄 **근거**: test_output.csv
+
+---
+
+## 🧪 개선 방향 제안
+
+- **슬라이싱 개선**: `va_arg` 구조와 Sink 호출을 포함한 함수 내부 흐름까지 반영
+- **심볼화 보완**: 함수 이름 보존 또는 위험 함수로의 주석 기반 tagging 필요
+- **AI 학습데이터 보강**: 포맷 문자열 여부(% 존재 등)를 기준으로 라벨링된 데이터 제공
+
+---
+
+## 취약점 세부 사항
+
+### 📁 관련 파일 소개
+
+| 파일명 | 설명 |
+|--------|------|
+| CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c | 콘솔 입력을 받아 `vprintf()` 호출에 전달하는 테스트 예제 |
 
 ---
 
 ### ❗️ 취약 코드
 
-**문제점**:  
-사용자 입력 `data`가 포맷 문자열로 `vprintf(data, args)`에 직접 전달됨.  
-이는 `%s`, `%n`, `%x` 등의 포맷 스트링 공격에 노출될 수 있음.
+**문제점**: 외부 입력을 포맷 문자열로 사용하여 포맷 문자열 취약점 발생
 
-#### Source: `CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c:40`
+#### Source: `CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c:63`
 ```c
 if (fgets(data+dataLen, (int)(100-dataLen), stdin) != NULL)
 ```
 
-#### Sink: `CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c:25`
+#### Sink: `CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c:42 (badVaSinkB)`
 ```c
-vprintf(data, args); // ⚠ 포맷 문자열 지정 없음
+vprintf(data, args); // 포맷 문자열 취약점 발생 가능
 ```
+
+---
 
 ### ✅ 개선 코드
 
-**패치 위치**: `동일 함수, format string 명시`
+**패치 위치**: `badVaSinkB → badVaSinkG`
+
 ```c
-vprintf("%s", args); // ✅ 안전: 포맷 명시
+vprintf("%s", args); // 포맷 문자열을 명시하여 안전한 출력
 ```
 
 **개선 방법**:
-사용자 입력을 그대로 포맷 문자열에 넣지 않고, 명시적으로 "%s"를 지정하여 format string 취약점을 방지함
+- 외부 입력값은 절대 포맷 문자열로 사용하지 않음
+- `%s` 등 명시적 포맷 사용으로 위험 회피
+
+---
+
+
+## 📊 탐지 결과
+
+|FileName|Caller|Source|Sink|idx|CWE-ID|category|criterion|line|label|predict|
+|--------|------|------|----|---|------|--------|---------|----|-----|-------|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|CWE134_Uncontrolled_Format_String__char_console_vprintf_12_bad|False|True|0|CWE-134|CallExpression|strlen|58|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|CWE134_Uncontrolled_Format_String__char_console_vprintf_12_bad|False|True|1|CWE-134|CallExpression|fgets|63|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|CWE134_Uncontrolled_Format_String__char_console_vprintf_12_bad|False|True|2|CWE-134|CallExpression|strlen|67|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|CWE134_Uncontrolled_Format_String__char_console_vprintf_12_bad|False|True|3|CWE-134|CallExpression|strcpy|85|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|goodB2G|False|True|4|CWE-134|CallExpression|strlen|136|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|goodB2G|False|True|5|CWE-134|CallExpression|fgets|141|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|goodB2G|False|True|6|CWE-134|CallExpression|strlen|145|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|goodB2G|False|True|7|CWE-134|CallExpression|strlen|164|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|goodB2G|False|True|8|CWE-134|CallExpression|fgets|169|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|goodB2G|False|True|9|CWE-134|CallExpression|strlen|173|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|goodG2B|False|True|10|CWE-134|CallExpression|strcpy|232|0|0|
+|CWE134_Uncontrolled_Format_String__char_console_vprintf_12.c|goodG2B|False|True|11|CWE-134|CallExpression|strcpy|237|0|0|

--- a/CWE134_FSB/SARD/char_environment_fprintf_45/README.md
+++ b/CWE134_FSB/SARD/char_environment_fprintf_45/README.md
@@ -1,112 +1,138 @@
 # 📁 SARD-char_environment_fprintf_45
 
+> Juliet 테스트케이스의 `char_environment_fprintf_45` 시나리오에서, 환경변수로부터 읽은 문자열을 `fprintf()` 함수에 포맷 문자열 없이 직접 전달하여 발생한 포맷 문자열 취약점(CWE-134)입니다.
+
 ## 🔍 취약점 개요
-* **취약점 종류**: [CWE-134](https://cwe.mitre.org/data/definitions/134.html) Uncontrolled Format String
-* **Source**: `char_environment`
-* **취약 조건**: 환경변수 입력을 포맷 문자열로 직접 사용
-* **Sink**: `fprintf()`
+
+**취약점 종류**: [[CWE-134](https://cwe.mitre.org/data/definitions/134.html)] Uncontrolled Format String
+
+* **Source**: 환경변수 입력 (`getenv`)
+* **취약 조건**: 외부 입력값을 검증 없이 포맷 문자열로 사용
+* **Sink**: `fprintf(stdout, data);`
+
+---
 
 ## 탐지 결과 요약
-총 슬라이스 수: 8개
-- KSignSlicer가
-    - 라벨 1(취약)으로 계산: 2개
-    - 라벨 0(정상)으로 계산: 6개
-- AI 모델이 
-    - 취약으로 탐지: 4개
-    - 정상으로 탐지: 4개
 
-### 탐지 결과
+| 총 슬라이스 수 | KSignSlicer 라벨 1 (취약) | KSignSlicer 라벨 0 (정상) | AI 취약 탐지 | AI 정상 탐지 |
+|----------------|---------------------------|----------------------------|---------------|---------------|
+| 8개            | 2개                       | 6개                        | 1개           | 7개           |
 
-| FileName                                                         | Caller                                                             | Source | Sink | idx | CWE-ID  | category       | criterion | line | label | token_length | predict |
-|------------------------------------------------------------------|--------------------------------------------------------------------|--------|------|-----|---------|----------------|-----------|------|-------|--------------|---------|
-| CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c | badSink                                                            | False  | True | 0   | CWE-134 | CallExpression | fprintf   | 42   | 1     | 19           | 1       |
-| CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c | CWE134_Uncontrolled_Format_String__char_environment_fprintf_45_bad | False  | True | 1   | CWE-134 | CallExpression | strlen    | 52   | 0     | 89           | 0       |
-| CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c | CWE134_Uncontrolled_Format_String__char_environment_fprintf_45_bad | False  | True | 2   | CWE-134 | CallExpression | strncat   | 58   | 0     | 89           | 0       |
-| CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c | goodG2BSink                                                        | False  | True | 3   | CWE-134 | CallExpression | fprintf   | 74   | 1     | 19           | 1       |
-| CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c | goodG2B                                                            | False  | True | 4   | CWE-134 | CallExpression | strcpy    | 83   | 0     | 40           | 1       |
-| CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c | goodB2GSink                                                        | False  | True | 5   | CWE-134 | CallExpression | fprintf   | 93   | 0     | 21           | 1       |
-| CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c | goodB2G                                                            | False  | True | 6   | CWE-134 | CallExpression | strlen    | 103  | 0     | 89           | 0       |
-| CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c | goodB2G                                                            | False  | True | 7   | CWE-134 | CallExpression | strncat   | 109  | 0     | 89           | 0       |
+Sink(`fprintf`) 관련 슬라이스는 총 3건 있었으며, 이 중 1건은 **취약으로 탐지됨**
+
+### ⚠️ 탐지 결과 문제점
+
+1. **Sink 정보는 있지만 Source 슬라이스 누락**  
+   - `getenv()` 호출 위치를 포함하는 슬라이스 부족
+2. **AI 분류 모델의 오탐 존재**  
+   - `fprintf(data)` 형태는 취약하지만 일부는 정상으로 예측됨
+3. **슬라이스 내 의미 단절**  
+   - 위험한 `fprintf()` 호출이 별도 문맥 없이 단일 구문으로만 표현됨
+
+---
+
+## 🧠 추가 분석 정보
+
+### 🔎 Slicer 추출 코드
+```c
+char * data = CWE134_Uncontrolled_Format_String__char_environment_fprintf_45_badData;
+fprintf(stdout, data);
+```
+- 📄 **근거**: slicer_result.json, slicer_result.symbolized.json
+
+---
+
+### 🧩 토큰화된 코드 (심볼화)
+```c
+char *Var1=Var2;
+fprintf(Var3,Var1);
+```
+- 📄 **근거**: slicer_result.symbolized.json
+
+---
+
+### 🔤 AI 입력 토큰 시퀀스
+```
+<s>, char, _, *, Var, 1, =, Var, 2, ;, _, fprintf, (, Var, 3, ,, Var, 1, ), ;, </s>
+```
+- 📄 **근거**: vectors.json
+
+---
+
+### 📉 벡터 예측 요약
+
+| idx | label | predict | 의미 |
+|-----|-------|---------|------|
+| 0   | 1     | 1       | ✅ 취약 슬라이스를 올바르게 탐지 |
+| 1   | 0     | 0       | ✅ 정상 슬라이스로 판단 |
+| 2   | 0     | 0       | ✅ 정상 |
+| 3   | 1     | 1       | ✅ 취약 |
+| 4~7| 0     | 0       | ✅ 정상으로 탐지함
+
+- 📄 **근거**: test_output.csv
+
+---
+
+## 🧪 개선 방향 제안
+
+- 슬라이싱 개선: Source부터 Sink까지 흐름을 반영한 슬라이스 구조 필요
+- 토큰 구조 보강: 포맷 문자열 유무 판단 가능하도록 `%` 토큰과의 관계 표현 필요
+- AI 학습 데이터 확장: 다양한 Source–Sink 조합과 위험한 문자열 흐름 포함 필요
+
+---
+
+## 취약점 세부 사항
+
+### 📁 관련 파일 소개
+
+| 파일명       | 설명                      |
+| ------------ | ------------------------- |
+| CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c | 환경변수 입력 후 `fprintf()` 호출이 포함된 테스트 코드 |
 
 ---
 
 ### ❗️ 취약 코드
 
-**문제점**:  
-환경변수에서 입력된 문자열이 포맷 문자열로 사용되며, 사용자에 의해 `%x`, `%n` 등의 포맷 스트링이 포함될 경우 코드 실행 흐름을 제어하거나 메모리 누출 등의 취약점이 발생할 수 있음.
+**문제점**: 환경변수 입력을 포맷 문자열로 사용하여 포맷 문자열 취약점이 발생
 
-#### Source: `CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c:42`
+#### Source: `CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c:52`
 ```c
 char * environment = GETENV(ENV_VARIABLE);
 if (environment != NULL)
-{
-    /* POTENTIAL FLAW: Read data from an environment variable */
     strncat(data+dataLen, environment, 100-dataLen-1);
-}
 ```
 
-#### Sink: `CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c:26`
+#### Sink: `CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c:42`
 ```c
-fprintf(stdout, data); // ⚠ 포맷 문자열 지정 없음
+fprintf(stdout, data); // 포맷 문자열 취약점 발생 가능
 ```
+
+---
 
 ### ✅ 개선 코드
 
-**패치 위치**: `goodB2GSink()`
+**패치 위치**: `CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c:42`
+
+#### 1. 포맷 문자열 명시
 ```c
-fprintf(stdout, "%s\n", data); // ✅ 포맷 명시
+fprintf(stdout, "%s", data); // 안전하게 출력
 ```
 
-**개선 방법**:
-사용자 입력이 포함된 문자열을 출력할 때는 반드시 "포맷 문자열"을 명시해줘야 함
-"fprintf(stdout, "%s", data);" 형태로 사용하면 포맷 스트링 인젝션 방지 가능
+**개선 방법**:  
+- 외부 입력값을 포맷 문자열로 직접 사용하는 것을 금지하고, 명시적 서식을 통해 출력
+- `snprintf()`와 같은 함수로 포맷 제어를 더 정밀하게 할 수도 있음
 
-## 🧠 추가 분석 정보
+---
 
-슬라이서가 해당 코드에 대해 취약하다고 판단한 기준은 다음과 같이 예상됩니다.
+## 📊 탐지 결과
 
-### 🔎 탐지된 취약 슬라이스의 공통 특징
-
-- `criterion`이 **`fprintf`**이며,
-- 코드에서 포맷 문자열을 명시하지 않고 사용자 입력을 그대로 전달하는 경우:
-
-```c
-fprintf(stdout, data); // ⚠ 포맷 문자열 없음
-```
-
-이와 같은 패턴을 포함한 슬라이스 (idx = 0, idx = 3)는 모두 `label = 1`로 지정되어 있습니다.
-
-즉, 슬라이서는 명확한 Sink(`fprintf`)와 포맷 문자열 미지정 상태를 취약 조건으로 판단하는 것으로 보입니다.
-
-### ⚠ 탐지되지 않은 슬라이스 (`label = 0`)의 특징
-
-`criterion`이 `strlen`, `strncat`, `strcpy` 등이고,
-
-`GETENV()` 호출 또는 `data` 할당/전달만 존재하는 경우:
-
-```c
-char * environment = GETENV(ENV_VARIABLE);
-if (environment != NULL)
-    strncat(data+dataLen, environment, ...);
-```
-
-Sink 함수 호출이 직접 포함되지 않거나,
-
-포맷 문자열이 명시된 경우 (`fprintf(stdout, "%s\n", data);`)는 모두 `label = 0` 처리되었습니다.
-
-### 📌 정리
-
-| 슬라이스 idx | 함수        | criterion | 내용 요약                   | label |
-| :----------: | ----------- | :-------- | :-------------------------- | :----: |
-|      0       | `badSink`   | `fprintf` | 포맷 문자열 없음            |   1    |
-|      3       | `goodG2BSink` | `fprintf` | 고정된 문자열 사용, 포맷 없음 |   1    |
-|      5       | `goodB2GSink` | `fprintf` | 포맷 문자열 있음 (`L"%s"`)  |   0    |
-|   1, 2, 4, 6, 7  | 기타        | `strlen`, `strncat`, `strcpy` | Sink 없음 또는 흐름 불완전    |   0    |
-
-### ✅ 시사점
-
-슬라이서는 `fprintf()` 호출이 있고, 포맷 문자열이 명시되지 않은 경우에만 `label = 1`로 탐지하는 것으로 보입니다.
-
-반대로, Source가 존재하더라도 Sink가 명시적으로 드러나지 않으면 탐지하지 못합니다.
-
-또한, 안전한 형태로 포맷 문자열이 명시되어 있으면 `label = 0`으로 올바르게 처리됩니다.
+|FileName|Caller|Source|Sink|idx|CWE-ID|category|criterion|line|label|predict|
+|--------|------|------|----|---|------|--------|---------|----|-----|-------|
+|CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c|badSink|False|True|0|CWE-134|CallExpression|fprintf|42|1|1|
+|CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c|CWE134_Uncontrolled_Format_String__char_environment_fprintf_45_bad|False|True|1|CWE-134|CallExpression|strlen|52|0|0|
+|CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c|CWE134_Uncontrolled_Format_String__char_environment_fprintf_45_bad|False|True|2|CWE-134|CallExpression|strncat|58|0|0|
+|CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c|goodG2BSink|False|True|3|CWE-134|CallExpression|fprintf|74|1|1|
+|CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c|goodG2B|False|True|4|CWE-134|CallExpression|strcpy|83|0|0|
+|CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c|goodB2GSink|False|True|5|CWE-134|CallExpression|fprintf|93|0|0|
+|CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c|goodB2G|False|True|6|CWE-134|CallExpression|strlen|103|0|0|
+|CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c|goodB2G|False|True|7|CWE-134|CallExpression|strncat|109|0|0|

--- a/CWE134_FSB/SARD/char_environment_fprintf_45/test_output.csv
+++ b/CWE134_FSB/SARD/char_environment_fprintf_45/test_output.csv
@@ -1,0 +1,9 @@
+FileName,Caller,Source,Sink,idx,CWE-ID,category,criterion,line,label,token_length,predict
+CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c,badSink,False,True,0,CWE-134,CallExpression,fprintf,42,1,19,1
+CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c,CWE134_Uncontrolled_Format_String__char_environment_fprintf_45_bad,False,True,1,CWE-134,CallExpression,strlen,52,0,89,0
+CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c,CWE134_Uncontrolled_Format_String__char_environment_fprintf_45_bad,False,True,2,CWE-134,CallExpression,strncat,58,0,89,0
+CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c,goodG2BSink,False,True,3,CWE-134,CallExpression,fprintf,74,1,19,1
+CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c,goodG2B,False,True,4,CWE-134,CallExpression,strcpy,83,0,40,1
+CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c,goodB2GSink,False,True,5,CWE-134,CallExpression,fprintf,93,0,21,1
+CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c,goodB2G,False,True,6,CWE-134,CallExpression,strlen,103,0,89,0
+CWE134_Uncontrolled_Format_String__char_environment_fprintf_45.c,goodB2G,False,True,7,CWE-134,CallExpression,strncat,109,0,89,0

--- a/CWE134_FSB/SARD/wchar_t_file_vfprintf_17/README.md
+++ b/CWE134_FSB/SARD/wchar_t_file_vfprintf_17/README.md
@@ -1,50 +1,134 @@
 # 📁 SARD-wchar_t_file_vfprintf_17
 
+> Juliet 테스트케이스의 `wchar_t_file_vfprintf_17` 시나리오에서는 외부 파일로부터 읽은 데이터를 `vfwprintf()` 함수에 포맷 문자열 없이 직접 전달하여 발생하는 포맷 문자열 취약점(CWE-134)을 다룹니다.
+
 ## 🔍 취약점 개요
-* **취약점 종류**: [CWE-134](https://cwe.mitre.org/data/definitions/134.html) Uncontrolled Format String
-* **Source**: `wchar_t_file` (파일로부터 입력)
-* **취약 조건**: 파일 입력값을 포맷 문자열로 직접 사용
-* **Sink**: `vfwprintf()`
+
+**취약점 종류**: [[CWE-134](https://cwe.mitre.org/data/definitions/134.html)] Uncontrolled Format String  
+* **Source**: 파일 입력 (`fgetws`)  
+* **취약 조건**: 외부 입력값을 `vfwprintf` 포맷 문자열로 직접 사용  
+* **Sink**: `vfwprintf(stdout, data, args);`
+
+---
 
 ## 탐지 결과 요약
-총 슬라이스 수: 6개
-- KSignSlicer가
-    - 라벨 1(취약)으로 계산: 0개
-    - 라벨 0(정상)으로 계산: 6개
-- AI 모델이 
-    - 취약으로 탐지: 0개
-    - 정상으로 탐지: 6개
 
-### 탐지 결과
+| 총 슬라이스 수 | KSignSlicer 라벨 1 (취약) | KSignSlicer 라벨 0 (정상) | AI 취약 탐지 | AI 정상 탐지 |
+|----------------|---------------------------|----------------------------|---------------|---------------|
+| 6개            | 0개                       | 6개                        | 0개           | 6개           |
 
-| FileName                                                      | Caller                                                          | Source | Sink | idx | CWE-ID  | category       | criterion | line | label | token_length | predict |
-|---------------------------------------------------------------|-----------------------------------------------------------------|--------|------|-----|---------|----------------|-----------|------|-------|--------------|---------|
-| CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c | CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17_bad | False  | True | 0   | CWE-134 | CallExpression | wcslen    | 54   | 0     | 120          | 0       |
-| CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c | CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17_bad | False  | True | 1   | CWE-134 | CallExpression | fopen     | 59   | 0     | 99           | 0       |
-| CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c | CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17_bad | False  | True | 2   | CWE-134 | CallExpression | fclose    | 69   | 0     | 99           | 0       |
-| CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c | goodB2G                                                         | False  | True | 3   | CWE-134 | CallExpression | wcslen    | 106  | 0     | 120          | 0       |
-| CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c | goodB2G                                                         | False  | True | 4   | CWE-134 | CallExpression | fopen     | 111  | 0     | 99           | 0       |
-| CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c | goodB2G                                                         | False  | True | 5   | CWE-134 | CallExpression | fclose    | 121  | 0     | 99           | 0       |
+### ⚠️ 탐지 결과 문제점
+
+1. **Sink 함수가 간접 호출로 단순화되어 탐지 누락**  
+   - `vfwprintf()`가 `va_arg` 구조 내부에서 호출되며, 심볼화 후 단순 `FUNC()` 구조로 표현됨
+
+2. **파일 읽기 Source와 Sink 간의 연결 단절**  
+   - `fgetws` → `vfwprintf` 흐름이 동일 슬라이스에 포함되지 않아 AI가 전체 흐름을 인식하지 못함
+
+3. **wide-character string 취급에 대한 모델 학습 부족**  
+   - `wchar_t`, `vfwprintf` 등 wide string 전용 함수에 대한 학습 데이터가 희소하여 일반 포맷 문자열 탐지보다 성능이 저조함
+
+---
+
+## 🧠 추가 분석 정보
+
+### 🔎 Slicer 추출 코드
+```c
+for(i = 0; i < 1; i++)
+    if (fgetws(data+dataLen, 100-dataLen, pFile) == NULL)
+        ...
+for(j = 0; j < 1; j++)
+    badVaSinkB(data, data); // sink 위치
+```
+- 📄 **근거**: slicer_result.json
+
+---
+
+### 🧩 토큰화된 코드 (심볼화)
+```c
+FUNC1(Var3, Var3);
+```
+- 심볼화 과정에서 `vfwprintf()`가 함수 이름이 제거되고 단순한 함수 호출 `FUNC1()`으로 표현됨
+- 포맷 문자열 여부나 wide string 여부 등 중요한 정보가 유실됨
+- 📄 **근거**: slicer_result.symbolized.json
+
+---
+
+### 🔤 AI 입력 토큰 시퀀스
+```
+<s>, int, wchar_t, *, Var, ..., FUNC1(Var, Var), ... </s>
+```
+- `%s` 등의 포맷 토큰이 없으며, Sink 함수명도 일반화되어 탐지 정확도 저하
+- 📄 **근거**: vectors.json
+
+---
+
+### 📉 벡터 예측 요약
+
+| idx | label | predict | 의미 |
+|-----|-------|---------|------|
+| 0~5 | 0     | 0       | 모두 정상으로 탐지됨
+
+- 📄 **근거**: test_output.csv
+
+---
+
+## 🧪 개선 방향 제안
+
+1. **Sink 추적 구조 강화**: `va_arg` 구조 내 Sink 함수 호출도 정확히 인식되도록 슬라이싱 및 심볼화 개선  
+2. **포맷 문자열 여부 보존**: 토큰화 시 `%` 토큰 존재 여부를 유지하여 위험 예측의 주요 단서로 활용  
+3. **wide-string 함수군 학습 보완**: `vfwprintf`, `fgetws`, `wchar_t` 기반 입력/출력 흐름에 대한 학습 샘플 확충
+
+---
+
+## 취약점 세부 사항
+
+### 📁 관련 파일 소개
+
+| 파일명 | 설명 |
+|--------|------|
+| CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c | 파일 입력 기반 wide-character 문자열을 포맷 문자열로 사용하는 테스트 코드 |
 
 ---
 
 ### ❗️ 취약 코드
 
-**문제점**:  
-파일에서 입력된 데이터를 포맷 문자열로 직접 사용하면서 `%x`, `%n` 등으로 포맷 스트링 공격에 악용될 수 있음
+**문제점**: 외부 입력을 `vfwprintf` 함수의 포맷 문자열로 직접 사용
 
-#### Sink: `CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c:27`
+#### Source: `CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c:63`
 ```c
-vfwprintf(stdout, data, args); // ⚠ 포맷 문자열 지정 없음
+if (fgetws(data+dataLen, (int)(100-dataLen), pFile) == NULL)
 ```
+
+#### Sink: `CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c:42 (badVaSinkB)`
+```c
+vfwprintf(stdout, data, args); // 포맷 문자열 취약
+```
+
+---
 
 ### ✅ 개선 코드
 
-**패치 위치**: `goodB2GVaSinkG() 함수 내부`
+**패치 위치**: `badVaSinkB → goodB2GVaSinkG`
+
 ```c
-vfwprintf(stdout, L"%s", args); // ✅ 포맷 문자열 명시
+vfwprintf(stdout, L"%s", args); // 포맷 문자열 명시
 ```
 
 **개선 방법**:
-사용자 입력이 포함된 문자열을 출력할 때는 반드시 "포맷 문자열"을 명시해줘야 함
-"fprintf(stdout, "%s", data);" 형태로 사용하면 포맷 스트링 인젝션 방지 가능
+- 외부 입력이 포맷 문자열로 사용되지 않도록 명시적 서식 지정
+- wide string 환경에서는 `%ls`, `%S` 등 확장 서식에 유의
+
+---
+
+
+## 📊 탐지 결과
+
+|FileName|Caller|Source|Sink|idx|CWE-ID|category|criterion|line|label|predict|
+|--------|------|------|----|---|------|--------|---------|----|-----|-------|
+|CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c|CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17_bad|False|True|0|CWE-134|CallExpression|wcslen|54|0|0|
+|CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c|CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17_bad|False|True|1|CWE-134|CallExpression|fopen|59|0|0|
+|CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c|CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17_bad|False|True|2|CWE-134|CallExpression|fclose|69|0|0|
+|CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c|goodB2G|False|True|3|CWE-134|CallExpression|wcslen|106|0|0|
+|CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c|goodB2G|False|True|4|CWE-134|CallExpression|fopen|111|0|0|
+|CWE134_Uncontrolled_Format_String__wchar_t_file_vfprintf_17.c|goodB2G|False|True|5|CWE-134|CallExpression|fclose|121|0|0|


### PR DESCRIPTION
##  주요 변경 사항

- CWE-134 관련 3개 케이스에 대해 README.md 파일을 업데이트된 SARD 템플릿 형식에 맞춰 재작성했습니다.
  - `char_console_vprintf_12`
  - `char_environment_fprintf_45`
  - `wchar_t_file_vfprintf_17`
- 각 보고서는 다음 항목들을 포함합니다:
  - 취약점 개요 및 조건 정리
  - 탐지 결과 요약
  - Source / Sink 코드 블록 명시
  - 개선 코드 및 방법 설명
  - AI 탐지 결과 및 슬라이스 분석 정보